### PR TITLE
Auto-Updater: fix date-stamp filtering, reduce report noise, improve MiniMax/xAI scraping

### DIFF
--- a/go-server/internal/models/data_test.go
+++ b/go-server/internal/models/data_test.go
@@ -89,7 +89,7 @@ func TestAtLeastThreeProviders(t *testing.T) {
 
 func TestTotalModelCount(t *testing.T) {
 	if len(Models) != 95 {
-		t.Errorf("expected 94 models, got %d", len(Models))
+		t.Errorf("expected 95 models, got %d", len(Models))
 	}
 }
 


### PR DESCRIPTION
# Auto-updater: reduce report noise with better date/alias/version filtering

## Summary

Addresses CodeRabbit review feedback from PR #3 and reduces false-positive "new model" noise in auto-updater reports. Key changes:

**Date-stamp filtering**: `dateStampRe` now catches both `YYYYMMDD` and `YYYY-MM-DD` suffixes (previously only caught the former, missing models like `gpt-5-2025-08-07`).

**Alias suffix expansion**: `isKnownAlias` now recognizes `-preview`, `-chat-latest`, `-non-reasoning`, `-reasoning`, and their `-latest` variants (previously only `-latest` and `-beta`). Also detects numeric version variants with ≥4-digit suffixes sharing a base with known models (e.g., `codestral-2405` when `codestral-2508` is known).


**Provider-specific improvements**:
- **OpenAI**: Added `ExcludePattern` to filter out legacy model families (`gpt-3.*`, `gpt-4`, `o1`) — reduces "new" count from 55 to 5
- **xAI**: Added `NormalizeRe` to convert `grok-4-1-fast` → `grok-4.1-fast` for consistent matching
- **MiniMax**: Primary URL changed to `platform.minimax.io/docs/guides/models-intro` (works without JS), pattern broadened to capture suffixes like `-lightning`, `-her-2`

**Test fix**: Corrected error message in `TestTotalModelCount` to say "expected 95" (was "expected 94" but assertion checked for 95).

## Review & Testing Checklist for Human

- [ ] **Verify OpenAI ExcludePattern doesn't drop current models**: Regex `^gpt-(?:3\.|4(?:-|$))|^o1(?:-|$)` should NOT match `gpt-4o`, `gpt-4.1`, `gpt-5.*`, `o3`, `o4-mini`. Run updater and confirm these appear in tracked models.
- [ ] **Verify xAI normalization works correctly**: `grok-4-1-fast` should become `grok-4.1-fast`, but `grok-4-0709` should stay unchanged (4-digit date suffix).
- [ ] **Spot-check isKnownAlias numeric variant logic**: The new block at lines 717-731 could be over-aggressive. Verify it doesn't incorrectly suppress genuinely new models.

**Recommended test plan**: Run `go run ./cmd/updater` locally and compare output to the previous version. OpenAI "NEW" count should drop significantly (55→5). Verify no legitimate new models are being filtered out.

### Notes
- Several doc comments were removed to reduce noise; CodeRabbit flagged docstring coverage as a warning (60% vs 80% threshold)
- No new unit tests added for the expanded filtering logic — existing diff tests pass but don't cover new edge cases

Link to Devin run: https://app.devin.ai/sessions/1be45b8725d548f9b141b6144cee0435
Requested by: @aezizhu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced model identifier normalization with flexible per-source configuration.
  * Improved detection and handling of model variants and aliases.
  * Extended date format support for better variant identification.

* **Tests**
  * Updated model count expectations in test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->